### PR TITLE
Users/dacarpen/fix openapi version field

### DIFF
--- a/rest-apis/M26/compliance_openapi.yaml
+++ b/rest-apis/M26/compliance_openapi.yaml
@@ -242,7 +242,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   title: Legal Service
   version: 1.0.0
-openapi: 3.1.0
+openapi: 3.0.0
 paths:
   /_ah/liveness_check:
     get:

--- a/rest-apis/M26/crs_catalog_v3_openapi.yaml
+++ b/rest-apis/M26/crs_catalog_v3_openapi.yaml
@@ -1292,7 +1292,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   title: CRS Catalog Service API
   version: 1.0.0
-openapi: 3.1.0
+openapi: 3.0.0
 paths:
   /_ah/liveness_check:
     get:

--- a/rest-apis/M26/crs_converter_openapi.yaml
+++ b/rest-apis/M26/crs_converter_openapi.yaml
@@ -1235,7 +1235,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   title: CRS Conversion Service
   version: 1.0.0
-openapi: 3.1.0
+openapi: 3.0.0
 paths:
   /_ah/liveness_check:
     get:

--- a/rest-apis/M26/dataset_openapi.yaml
+++ b/rest-apis/M26/dataset_openapi.yaml
@@ -209,7 +209,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   title: Dataset Service
   version: 1.0.0
-openapi: 3.1.0
+openapi: 3.0.0
 paths:
   /getDatasetRegistry:
     get:

--- a/rest-apis/M26/dataset_openapi.yaml
+++ b/rest-apis/M26/dataset_openapi.yaml
@@ -954,7 +954,5 @@ tags:
   name: dataset
 - description: Health Check API
   name: health-check-api
-- description: dataset api operations
-  name: dataset
 - description: Version info endpoint
   name: info

--- a/rest-apis/M26/eds_openapi.yaml
+++ b/rest-apis/M26/eds_openapi.yaml
@@ -77,7 +77,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   title: External Data Sources Data Management Service APIs
   version: 2.0.0
-openapi: 3.1.0
+openapi: 3.0.0
 paths:
   /health/liveness_check:
     get:

--- a/rest-apis/M26/entitlements_openapi.yaml
+++ b/rest-apis/M26/entitlements_openapi.yaml
@@ -231,7 +231,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   title: Entitlements Service
   version: '2.0'
-openapi: 3.1.0
+openapi: 3.0.0
 paths:
   /_ah/liveness_check:
     get:

--- a/rest-apis/M26/file_service_openapi.yaml
+++ b/rest-apis/M26/file_service_openapi.yaml
@@ -335,7 +335,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   title: File Service
   version: 2.0.0
-openapi: 3.1.0
+openapi: 3.0.0
 paths:
   /v2/files/metadata:
     post:

--- a/rest-apis/M26/indexer_openapi.yaml
+++ b/rest-apis/M26/indexer_openapi.yaml
@@ -90,7 +90,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   title: Indexer Service
   version: '2.0'
-openapi: 3.1.0
+openapi: 3.0.0
 paths:
   /index:
     delete:

--- a/rest-apis/M26/notification_openapi.yaml
+++ b/rest-apis/M26/notification_openapi.yaml
@@ -71,7 +71,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   title: Notification Service
   version: 1.0.0
-openapi: 3.1.0
+openapi: 3.0.0
 paths:
   /_ah/warmup:
     get:

--- a/rest-apis/M26/register_openapi.yaml
+++ b/rest-apis/M26/register_openapi.yaml
@@ -325,7 +325,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   title: Register Service
   version: '1.0'
-openapi: 3.1.0
+openapi: 3.0.0
 paths:
   /action:
     post:

--- a/rest-apis/M26/schema_openapi.yaml
+++ b/rest-apis/M26/schema_openapi.yaml
@@ -194,7 +194,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   title: Schema Service
   version: '1.0'
-openapi: 3.1.0
+openapi: 3.0.0
 paths:
   /info:
     get:

--- a/rest-apis/M26/search_openapi.yaml
+++ b/rest-apis/M26/search_openapi.yaml
@@ -280,7 +280,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   title: Search Service
   version: '2.0'
-openapi: 3.1.0
+openapi: 3.0.0
 paths:
   /info:
     get:

--- a/rest-apis/M26/secret_openapi.yaml
+++ b/rest-apis/M26/secret_openapi.yaml
@@ -127,7 +127,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   title: Secret Service API
   version: 1.0.0
-openapi: 3.1.0
+openapi: 3.0.0
 paths:
   /v1/health:
     get:

--- a/rest-apis/M26/storage_openapi.yaml
+++ b/rest-apis/M26/storage_openapi.yaml
@@ -542,7 +542,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   title: Storage Service
   version: 2.0.0
-openapi: 3.1.0
+openapi: 3.0.0
 paths:
   /info:
     get:

--- a/rest-apis/M26/storage_openapi.yaml
+++ b/rest-apis/M26/storage_openapi.yaml
@@ -1962,9 +1962,7 @@ tags:
   name: query
 - description: Health Check API
   name: health-check-api
-- description: Copying record references management operations
-  name: records
-- description: Records management operations
+- description: Records management operations, including copying record references
   name: records
 - description: Version info endpoint
   name: info

--- a/rest-apis/M26/unit_openapi.yaml
+++ b/rest-apis/M26/unit_openapi.yaml
@@ -590,7 +590,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   title: Unit Service API
   version: 3.0.0
-openapi: 3.1.0
+openapi: 3.0.0
 paths:
   /v3/_ah/liveness_check:
     get:

--- a/rest-apis/M26/wellbore_ddms_openapi.yaml
+++ b/rest-apis/M26/wellbore_ddms_openapi.yaml
@@ -783,7 +783,7 @@ info:
   description: build local
   title: Wellbore DDMS OSDU
   version: '0.29'
-openapi: 3.1.0
+openapi: 3.0.0
 paths:
   /about:
     get:


### PR DESCRIPTION
# PR: Fix M26 REST API specs failing to render in Swagger UI

**Create PR:** https://github.com/microsoft/adme-samples/pull/new/users/dacarpen/fix-openapi-version-field

- **Branch:** `users/dacarpen/fix-openapi-version-field` -> `main`
- **Commits:** `df38db8`, `a36e7dc`

---

## Title

```
Fix M26 REST API specs failing to render in Swagger UI
```

## Description

## Summary

The published REST API reference site (https://microsoft.github.io/adme-samples/) was failing to render 16 of the 22 M26 specs, plus showing duplicate-tag validator warnings. This fixes both.

## Root Cause

- **Version field:** 16 M26 specs declared `openapi: 3.1.0`, but the deployed Swagger UI (v4.5.0) only supports `swagger: 2.0` and `openapi: 3.0.n`. This produced: *"The provided definition does not specify a valid version field."*
- **Duplicate tags:** the `dataset` and `storage` specs each declared the same global tag name twice, producing: *"attribute tags.&lt;name&gt; is repeated."*

## Changes

- Changed `openapi: 3.1.0` -> `openapi: 3.0.0` in 16 M26 specs. The specs use only 3.0 constructs (e.g. `nullable`) and no 3.1-only features, so 3.0.0 is accurate:
  compliance, crs_catalog_v3, crs_converter, dataset, eds, entitlements, file_service, indexer, notification, register, schema, search, secret, storage, unit, wellbore_ddms.
- Merged duplicate global `tags` entries into single entries (preserving descriptions) in `dataset_openapi.yaml` (`dataset`) and `storage_openapi.yaml` (`records`).

## Testing

- Resolved all 22 M26 specs with `swagger-client` (the parser Swagger UI uses): all 22 are render-ready; the 16 changed files now parse as OAS3 (openapi 3.0.0) with `$ref`s resolving cleanly.